### PR TITLE
[Tasks] UX enhancement: use dueDate as initial value for reminder date

### DIFF
--- a/karman_app/lib/components/reminders/task_reminder.dart
+++ b/karman_app/lib/components/reminders/task_reminder.dart
@@ -29,6 +29,7 @@ class TaskReminderState extends State<TaskReminder>
   late AnimationController _animationController;
   late Animation<double> _animation;
   DateTime? _selectedDateTime;
+  bool _wasDateTimeSelected = false;
 
   @override
   void initState() {
@@ -50,6 +51,14 @@ class TaskReminderState extends State<TaskReminder>
     super.dispose();
   }
 
+  @override
+  void didUpdateWidget(TaskReminder oldWidget) {
+    if (oldWidget.dateTime != widget.dateTime && widget.dateTime != null) {
+      if (!_wasDateTimeSelected) _selectedDateTime = widget.dateTime;
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
   void _togglePicker(bool value) {
     widget.onToggle(value);
     if (value) {
@@ -69,6 +78,7 @@ class TaskReminderState extends State<TaskReminder>
   void _handleDateTimeSelection(DateTime dateTime) {
     setState(() {
       _selectedDateTime = dateTime;
+      _wasDateTimeSelected = true;
     });
     widget.onDateTimeSelected(dateTime);
   }

--- a/karman_app/lib/components/task/taskDetailsWidgets/task_options_section.dart
+++ b/karman_app/lib/components/task/taskDetailsWidgets/task_options_section.dart
@@ -39,7 +39,7 @@ class TaskOptionsSection extends StatelessWidget {
         SizedBox(height: 20),
         TaskReminder(
           isEnabled: isReminderEnabled,
-          dateTime: reminder,
+          dateTime: reminder ?? dueDate,
           onToggle: onReminderToggle,
           onDateTimeSelected: onReminderSet,
           title: 'Reminder',


### PR DESCRIPTION
Hey team, thanks for open sourcing your beautiful app!

I would personally prefer having a reminder time placed somewhere close to the chosen due date of a Task. I think it's not uncommon to create "backlog" tasks, with due date several weeks ahead, which you don't want to be reminded of today or tomorrow. 
